### PR TITLE
Fix Branches, CM-7.2.0 -> Gingerbread diff

### DIFF
--- a/local_manifest.xml
+++ b/local_manifest.xml
@@ -1,23 +1,23 @@
-  <manifest>
-  <remote name="BroadcomCM" fetch="git://github.com/BroadcomCM/" />
+<manifest>
+  <remote name="BroadcomCM" fetch="https://github.com/" />
   
   <!-- CyanogenMod repositories -->
   <remove-project name="CyanogenMod/android_frameworks_base" />
   
   <!-- BroadcomCM repositories -->
-  <project path="frameworks/base" name="BroadcomCM/android_frameworks_base" remote="BroadcomCM" revision="gingerbread"/>
+  <project path="frameworks/base" name="broadcomCM/android_frameworks_base" remote="BroadcomCM" revision="gingerbread"/>
   
   <!-- SAMSUNG BCM21553 device tree and vendor -->
-  <project path="device/samsung/totoro" name="BroadcomCM/android_device_samsung_totoro" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="device/samsung/cooperve" name="BroadcomCM/android_device_samsung_cooperve" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="device/samsung/tassve" name="BroadcomCM/android_device_samsung_tassve" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="device/samsung/cori" name="BroadcomCM/android_device_samsung_cori" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="device/samsung/bcm21553-common" name="BroadcomCM/android_device_samsung_bcm21553-common" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="vendor/samsung" name="BroadcomCM/android_vendor_samsung" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="device/samsung/totoro" name="broadcomCM/android_device_samsung_totoro" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="device/samsung/cooperve" name="broadcomCM/android_device_samsung_cooperve" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="device/samsung/tassve" name="broadcomCM/android_device_samsung_tassve" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="device/samsung/cori" name="broadcomCM/android_device_samsung_cori" remote="BroadcomCM" revision="gingerbread"/>
+  <project path="device/samsung/bcm21553-common" name="broadcomCM/android_device_samsung_bcm21553-common" remote="BroadcomCM" revision="gingerbread"/>
+  <project path="vendor/samsung" name="broadcomCM/android_vendor_samsung" remote="BroadcomCM" revision="gingerbread"/>
   
   <!-- ALCATEL BCM21553 device tree and vendor-->
-  <project path="device/alcatel/v860" name="BroadcomCM/android_device_alcatel_v860" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="device/alcatel/bcm21553-common" name="BroadcomCM/android_device_alcatel_bcm21553-common" remote="BroadcomCM" revision="cm-7.2.0"/>
-  <project path="vendor/alcatel" name="BroadcomCM/android_vendor_alcatel" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="device/alcatel/v860" name="broadcomCM/android_device_alcatel_v860" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="device/alcatel/bcm21553-common" name="broadcomCM/android_device_alcatel_bcm21553-common" remote="BroadcomCM" revision="cm-7.2.0"/>
+  <project path="vendor/alcatel" name="broadcomCM/android_vendor_alcatel" remote="BroadcomCM" revision="gingerbread"/>
   
 </manifest>


### PR DESCRIPTION
CM-7.2.0 Branches weren't made for all devices / repo's. Several still had gingerbread as branch, so i adjusted them to match.
